### PR TITLE
Update project launch dates with exact release days

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@
 | [PlanAssistant](https://songtianlun.github.io/PlanAssistant/) | For people who like to record their lives and plan their goals. | [Git](https://github.com/songtianlun/PlanAssistant) [入口](https://songtianlun.github.io/PlanAssistant/) [Docs](https://songtianlun.github.io/PlanAssistant/) | `SINCE 2019` `Android` `Java` |
 | [BJ-PFD2](https://bjpfd2.skybyte.me) | 个人财务管理方案及监控看板 | [Git](https://github.com/songtianlun/bj-pfd2) [入口](https://bjpfd2.skybyte.me) [介绍文章](https://frytea.com/archives/1132/) | `SINCE 2022` `Go` `Finance` `Dashboard` |
 | MinePin | 个人地理位置收藏夹 | [Git](https://github.com/songtianlun/minepin) | `SINCE 2022` `Go` `Maps` `Location` |
-| [全球艺术天气](https://todayaiweather.com/) | 生成全球城市天气艺术图像，15w+城市，5k+AIArt | [入口](https://todayaiweather.com/) [介绍文章](https://frytea.com/archives/1430/) | `SINCE 2025` `Ruby` `AI` `Art` `Weather` |
+| [全球艺术天气](https://todayaiweather.com/) | 生成全球城市天气艺术图像，15w+城市，5k+AIArt | [入口](https://todayaiweather.com/) [介绍文章](https://frytea.com/archives/1430/) | `SINCE 2024-12-27` `Ruby` `AI` `Art` `Weather` |
 | mirrorGit | 将 GitHub 仓库镜像到 Gitea 的 Shell 脚本 | [Git](https://github.com/songtianlun/mirrorGit) | `SINCE 2025` `Shell` `Git` `Mirror` |
 | [Selfhost Hub](https://selfhost-hub.com/) | 自托管服务和工具目录 | [Git](https://github.com/songtianlun/selfhost-hub) [入口](https://selfhost-hub.com/) | `SINCE 2025` `NextJS` `React` `Selfhost` |
 | [FinanceCalculator](https://fc.frytea.com/) | 快速选出收益最高的理财产品 | [入口](https://fc.frytea.com/) [介绍文章](https://frytea.com/archives/1490/) | `SINCE 2025` `NextJS` `Finance` `Calculator` |
-| [PlayUnb](https://playunb.com/) | 小游戏站，打开即玩超级玛丽、魂斗罗等经典游戏 | [Git](https://github.com/songtianlun/PlayUnb-Assets) [入口](https://playunb.com/) [介绍文章](https://frytea.com/archives/1492/) | `SINCE 2025` `JavaScript` `Games` `Emulator` |
-| [LiquedGlass](https://liquidglass.icu/) | 液态玻璃风格图像生成和模拟 | [入口](https://liquidglass.icu/) [介绍文章](https://frytea.com/archives/1489/) | `SINCE 2025` `NextJS` `AI` `Design` |
+| [PlayUnb](https://playunb.com/) | 小游戏站，打开即玩超级玛丽、魂斗罗等经典游戏 | [Git](https://github.com/songtianlun/PlayUnb-Assets) [入口](https://playunb.com/) [介绍文章](https://frytea.com/archives/1492/) | `SINCE 2025-05-17` `JavaScript` `Games` `Emulator` |
+| [LiquedGlass](https://liquidglass.icu/) | 液态玻璃风格图像生成和模拟 | [入口](https://liquidglass.icu/) [介绍文章](https://frytea.com/archives/1489/) | `SINCE 2025-06-10` `NextJS` `AI` `Design` |
 | [Umami Dashboard](https://ud.frytea.com/) | 更直观的展示 Umami 所有网站统计数据 | [Git](https://github.com/songtianlun/umami-dashboard) [入口](https://ud.frytea.com/) | `SINCE 2025` `NextJS` `Analytics` `Dashboard` |
-| [Week Count](https://weekcount.com/) | 每年有多少周，当前是第几周，任意日期的周计算 | [入口](https://weekcount.com/) | `SINCE 2025` `NextJS` `Calendar` `Utility` |
-| [Calc9](https://calc9.com/) | 用于健康、健身和日常计算的专业计算器工具集合 | [入口](https://calc9.com/) | `SINCE 2025` `NextJS` `Health` `Calculator` |
+| [Week Count](https://weekcount.com/) | 每年有多少周，当前是第几周，任意日期的周计算 | [入口](https://weekcount.com/) | `SINCE 2025-06-24` `NextJS` `Calendar` `Utility` |
+| [Calc9](https://calc9.com/) | 用于健康、健身和日常计算的专业计算器工具集合 | [入口](https://calc9.com/) | `SINCE 2025-06-30` `NextJS` `Health` `Calculator` |
 | [Anything vs Anything](https://ava.skybyte.me/) | 万物皆可比，使用AI智能分析比较任何两个事物 | [入口](https://ava.skybyte.me/) | `SINCE 2025` `NextJS` `AI` `Comparison` |
 | [Awesome Prompts](https://prmbr.com/) | 开源提示词仓库与精选分享 | [Git](https://github.com/songtianlun/awesome-prompts) [入口](https://prmbr.com/) | `SINCE 2025` `NextJS` `AI` `Prompts` |
 


### PR DESCRIPTION
## Summary
- update the launch date for Global Art Weather to 2024-12-27
- record precise launch dates for PlayUnb, LiquidGlass, Week Count, and Calc9

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce0ff49d10833381f81e6f52d7d891